### PR TITLE
[Windows Compatibility] Use `.fsPath` instead of `.path`

### DIFF
--- a/src/owner-display.ts
+++ b/src/owner-display.ts
@@ -35,7 +35,7 @@ export class OwnerDisplay {
   public refreshOwnersFile() {
     try {
       this.codeowners = new Codeowners(
-        vscode.workspace.workspaceFolders![0].uri.path
+        vscode.workspace.workspaceFolders![0].uri.fsPath
       );
       this.teamInfo = new Map(
         this.codeowners.contactInfo


### PR DESCRIPTION
On Windows, that `.path` property returns something like `"/c:/data/project"` that doesn't work for `Codeowners`, whereas `.fsPath` in this case is `"c:\\data\\project"` which works end to end in local testing.

### Manual test cases
- [x] Confirm locally that with this change, it still works on *nix